### PR TITLE
add feishu_bot.yml

### DIFF
--- a/.github/workflows/feishu_bot.yml
+++ b/.github/workflows/feishu_bot.yml
@@ -1,0 +1,54 @@
+name: Notify Feishu on Issue, PR, or Commit
+
+on:
+  issues:
+    types: [opened, closed]
+  pull_request:
+    types: [opened, closed]
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  notify_feishu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send message to Feishu
+        env:
+          FEISHU_WEBHOOK_URL: ${{ secrets.FEISHU_WEBHOOK_URL }} # 建议将 机器人的webhook URL 存储在 GitHub Secrets 中
+        run: |
+          EVENT_TYPE="${{ github.event_name }}"
+          TIMESTAMP=$(TZ=Asia/Shanghai date +"%Y-%m-%d %H:%M:%S") # 获取当前北京时间
+          
+
+          echo "Event type: $EVENT_TYPE"
+          echo "Timestamp: $TIMESTAMP"
+          
+          if [ "$EVENT_TYPE" = "issues" ]; then
+            ISSUE_TITLE="${{ github.event.issue.title }}"
+            ISSUE_NUMBER="${{ github.event.issue.number }}"
+            ISSUE_URL="${{ github.event.issue.html_url }}"
+            ISSUE_STATE="${{ github.event.issue.state }}" # 获取 issue 的状态（如 open 或 closed）
+            ISSUE_USER="${{ github.event.issue.user.login }}" # 获取操作者的用户名
+            MESSAGE="{\"msg_type\":\"text\",\"content\":{\"text\":\"Issue #$ISSUE_NUMBER: $ISSUE_TITLE\nState: $ISSUE_STATE\nEdited by: $ISSUE_USER\nTimestamp: $TIMESTAMP\n$ISSUE_URL\"}}"
+          elif [ "$EVENT_TYPE" = "pull_request" ]; then
+            PR_TITLE="${{ github.event.pull_request.title }}"
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            PR_URL="${{ github.event.pull_request.html_url }}"
+            PR_USER="${{ github.event.pull_request.user.login }}" # 获取 PR 的操作者
+            PR_STATE="${{ github.event.pull_request.state }}" # 获取 PR 的状态
+            MESSAGE="{\"msg_type\":\"text\",\"content\":{\"text\":\"PR #$PR_NUMBER: $PR_TITLE\nState: $PR_STATE\nOpened by: $PR_USER\nTimestamp: $TIMESTAMP\n$PR_URL\"}}"
+          elif [ "$EVENT_TYPE" = "push" ]; then
+            COMMIT_MESSAGE="${{ github.event.head_commit.message }}" # 获取提交信息
+            COMMIT_AUTHOR="${{ github.event.head_commit.author.name }}" # 获取提交作者
+            COMMIT_URL="${{ github.event.head_commit.url }}" # 获取提交的 URL
+            COMMIT_ID="${{ github.event.head_commit.id }}" # 获取提交的 commit ID
+            MESSAGE="{\"msg_type\":\"text\",\"content\":{\"text\":\"New Commit:\nMessage: $COMMIT_MESSAGE\nAuthor: $COMMIT_AUTHOR\nCommit ID: $COMMIT_ID\nTimestamp: $TIMESTAMP\n$COMMIT_URL\"}}"
+          else
+            echo "Unsupported event type: $EVENT_TYPE"
+            exit 1
+          fi
+          
+          # Send the message to Feishu
+          curl -X POST -H "Content-Type: application/json" -d "$MESSAGE" "$FEISHU_WEBHOOK_URL"


### PR DESCRIPTION
添加了feishu_bot，要把群聊中的机器人webhook的url加入到github 的secret中可正常调用机器人,可以侦测issue，pr和主分支的提交,经过测试，之后抽空完成服务卡片的api接口对齐让他变得更美观。